### PR TITLE
Propagate the `verify` setting to individual requests

### DIFF
--- a/napalm_servertech_pro2/pro2.py
+++ b/napalm_servertech_pro2/pro2.py
@@ -26,7 +26,7 @@ class PRO2Driver(NetworkDriver):
     def _req(self, path, method="GET", json=None, raise_err=True):
         url = f"https://{self.hostname}/jaws{path}"
         try:
-            req = self.api.request(method, url=url, json=json)
+            req = self.api.request(method, url=url, json=json, verify=self.verify)
             req.raise_for_status()
         except requests.exceptions.HTTPError as err:
             if raise_err:
@@ -43,7 +43,9 @@ class PRO2Driver(NetworkDriver):
 
         try:
             req = self.api.request(
-                "GET", url=f"https://{self.hostname}/jaws/monitor/system"
+                "GET",
+                url=f"https://{self.hostname}/jaws/monitor/system",
+                verify=self.verify,
             )
             req.raise_for_status()
         except requests.exceptions.ConnectionError:


### PR DESCRIPTION
Due to https://github.com/psf/requests/issues/3829, the `verify` flag
has no effect on Sssions when the `REQUESTS_CA_BUNDLE` env variable is set.