### PR TITLE
Support singular form in uptime string

### DIFF
--- a/napalm_servertech_pro2/utils.py
+++ b/napalm_servertech_pro2/utils.py
@@ -4,8 +4,8 @@ import re
 def convert_uptime(uptime):
     """Converts a ServerTech uptime string to a number of seconds."""
     time_regex = (
-        r"^(?P<days>\d+) days (?P<hours>\d+) hours"
-        r" (?P<minutes>\d+) minutes (?P<seconds>\d+) seconds$"
+        r"^(?P<days>\d+) days? (?P<hours>\d+) hours?"
+        r" (?P<minutes>\d+) minutes? (?P<seconds>\d+) seconds?$"
     )
     m = re.match(
         time_regex,

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -8,7 +8,10 @@ def test_convert_uptime():
     uptime = "11 days 4 hours 8 minutes 6 seconds"
     assert utils.convert_uptime(uptime) == 965286
 
-    uptime = "0 days 0 hours 0 minutes 1 seconds"
+    uptime = "133 days 1 hour 12 minutes 15 seconds"
+    assert isinstance(utils.convert_uptime(uptime), int)
+
+    uptime = "0 days 0 hours 0 minutes 1 second"
     assert utils.convert_uptime(uptime) == 1
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
Sometimes the uptime is only "1 something", so we need the regex to
accept those values.