### PR TITLE
Detect software version via HTTP headers

### DIFF
--- a/napalm_servertech_pro2/pro2.py
+++ b/napalm_servertech_pro2/pro2.py
@@ -17,6 +17,7 @@ from napalm_servertech_pro2.utils import (
     convert_uptime,
     parse_hardware,
     validate_actions,
+    server_version,
 )
 
 
@@ -67,6 +68,12 @@ class PRO2Driver(NetworkDriver):
         except requests.exceptions.ConnectionError:
             self.api = None
             raise ConnectionException
+
+        version = server_version(req.headers)
+        if version and version < "8.0m":
+            raise EnvironmentError(
+                f"This device is running {version}, while the API was released in 8.0m"
+            )
 
     def close(self):
         self.api.close()

--- a/napalm_servertech_pro2/utils.py
+++ b/napalm_servertech_pro2/utils.py
@@ -45,3 +45,12 @@ def validate_actions(action, supported_actions):
             " the list of valid actions is: {}".format(", ".join(supported_actions))
         )
     return True
+
+
+def server_version(headers):
+    """Extract the firmware version from HTTP headers."""
+    version_re = re.compile(r"ServerTech-AWS/v(?P<version>\d+\.\d+\w+)")
+    if headers.get("Server"):
+        match = version_re.match(headers["Server"])
+        if match:
+            return match.group("version")

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -34,3 +34,15 @@ def test_validate_actions():
 
     with pytest.raises(ValueError):
         utils.validate_actions("oof", supported_actions)
+
+
+def test_server_version():
+    headers = {"Server": "ServerTech-AWS/v8.0k"}
+    assert utils.server_version(headers) == "8.0k"
+
+    headers = {"Server": "lol"}
+    assert utils.server_version(headers) is None
+
+    assert "8.0v" > "8.0m"
+
+    assert "8.0k" < "8.0m"


### PR DESCRIPTION
PDUs actually send the running version in the `Server` HTTP header (ie:
ServerTech-AWS/v8.0k), so we can use this value to know if the version
running supports the API (it was introduced in `8.0m`). If that is not
the case, we will error-out for now (maybe one day we will implement a
CLI driver ¯\_(ツ)_/¯.