### PR TITLE
Prepare release 0.1.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ __author__ = "Antoine Meillet <antoine.meillet@gmail.com>"
 
 setup(
     name="napalm-servertech-pro2",
-    version="0.1.4",
+    version="0.1.5",
     packages=find_packages(),
     author="Antoine Meillet",
     author_email="antoine.meillet@gmail.com",


### PR DESCRIPTION
Following https://github.com/napalm-automation-community/napalm-servertech-pro2/pull/11, I couldn't see any dependency on a particular netaddr version so should be fine to go ahead and release a new version.